### PR TITLE
feat: toPng 固定导出的最长边，默认 8 * 1024 ，可由传参更改

### DIFF
--- a/packages/core/src/canvas/canvas.ts
+++ b/packages/core/src/canvas/canvas.ts
@@ -6753,7 +6753,13 @@ export class Canvas {
     };
   }
 
-  toPng(padding: Padding = 2, callback?: BlobCallback, containBkImg = false) {
+  toPng(
+    padding: Padding = 2,
+    callback?: BlobCallback,
+    containBkImg = false,
+    // 默认值 8k
+    { longSide = 8 * 1024 }: { longSide?: number } = {}
+  ) {
     const rect = getRect(this.store.data.pens);
     if (!isFinite(rect.width)) {
       throw new Error('can not to png, because width is not finite');
@@ -6791,6 +6797,13 @@ export class Canvas {
     rect.y -= p[0];
     rect.width += p[3] + p[1];
     rect.height += p[0] + p[2];
+
+    // 扩大图
+    const scale =
+      rect.width > rect.height ? longSide / rect.width : longSide / rect.height;
+    rect.width *= scale;
+    rect.height *= scale;
+
     calcRightBottom(rect);
 
     const canvas = document.createElement('canvas');
@@ -6810,6 +6823,7 @@ export class Canvas {
     }
     const ctx = canvas.getContext('2d');
     ctx.textBaseline = 'middle'; // 默认垂直居中
+    ctx.scale(scale, scale);
     if (isDrawBkImg) {
       const x = rect.x < 0 ? -rect.x : 0;
       const y = rect.y < 0 ? -rect.y : 0;


### PR DESCRIPTION
https://github.com/le5le-com/meta2d.js/pull/213

toPng 导出的图片的宽高是和 getRect 的宽高相关的，所以用户放大的越大（即 scale 越大），再去导出图片时，导出的图片越清晰，像素值越高（但是过大会导致 canvas 无法支持导出）。
像素值不应该由用户的缩放操作来改变。新加的参数 longSide （默认值 8 * 1024）可以固定导出图片的长边值（即长边像素值），这样就可以保证导出的图片清晰度的可控了。
从交互上来讲，可以做成，在点击下载 png 图片时，弹出一个对话框，由用户选择大小（长边像素值），例如 4*1024 ， 8*1024，16*1024 等，这样就可以满足用户的期望了