### PR TITLE
feat: 移除多余代码

### DIFF
--- a/packages/chart-diagram/src/echarts.ts
+++ b/packages/chart-diagram/src/echarts.ts
@@ -72,9 +72,6 @@ export function echarts(pen: ChartPen): Path2D {
       pen.echarts = JSON.parse(pen.echarts);
     } catch (e) {}
   }
-  if (!pen.echarts) {
-    return;
-  }
   keyWords =
     pen.calculative.canvas.store.options.diagramOptions['chart']?.keyWords ||
     keyWords;


### PR DESCRIPTION
echarts函数在前面已经判断过pen.echarts为空的情况，这里应该不需要重复判断。
<img width="495" alt="image" src="https://github.com/le5le-com/meta2d.js/assets/90412675/b1f1cec5-1cc9-47b6-b783-d97801ac3191">
